### PR TITLE
Add environment variable to allow for custom pvc directory mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A tool to dynamically provision Kubernetes HostPath Volumes in single-node Kuber
 
 It is based on [kubernetes-sigs/sig-storage-lib-external-provisioner/hostpath-provisioner](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/tree/master/examples/hostpath-provisioner) example project.
 
+## Additional Environment Variables
+
+`PVC_DIRECTORY` - Use this to set a custom directory as your hostpath mount point. If blank, uses default `/mnt/hostpath`
+
 ## TL;DR
 
 ```bash

--- a/hostpath-provisioner.go
+++ b/hostpath-provisioner.go
@@ -49,12 +49,20 @@ type hostPathProvisioner struct {
 // NewHostPathProvisioner creates a new hostpath provisioner
 func NewHostPathProvisioner() controller.Provisioner {
 	nodeName := os.Getenv("NODE_NAME")
+	pvcDirectory := os.Getenv("PVC_DIRECTORY")
 	if nodeName == "" {
 		glog.Fatal("env variable NODE_NAME must be set so that this provisioner can identify itself")
 	}
-	return &hostPathProvisioner{
-		pvDir:    "/mnt/hostpath",
-		identity: nodeName,
+	if pvcDirectory == "" {
+		return &hostPathProvisioner{
+			pvDir:    "/mnt/hostpath",
+			identity: nodeName,
+		}
+	} else {
+		return &hostPathProvisioner{
+			pvDir:    pvcDirectory,
+			identity: nodeName,
+		}
 	}
 }
 


### PR DESCRIPTION
We wanted to the ability to customise the directory which the hostpath provisioned new volumes into.

This PR does that.

It does not account for validation of entered directory, its set assuming that the env var `PVC_DIRECTORY` is set to a directory path. E.g `/var/directories/hostpath` 

If unset, it'll use the default `/mnt/hostpath`