### PR TITLE
Allow the node hostpath to be set from helm chart env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 IMAGE?=quay.io/rimusz/hostpath-provisioner
 
-TAG_GIT=$(IMAGE):v0.2.1
+TAG_GIT=$(IMAGE):v0.2.2
 TAG_LATEST=$(IMAGE):latest
 
 PHONY: all

--- a/hostpath-provisioner.go
+++ b/hostpath-provisioner.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -52,8 +52,12 @@ func NewHostPathProvisioner() controller.Provisioner {
 	if nodeName == "" {
 		glog.Fatal("env variable NODE_NAME must be set so that this provisioner can identify itself")
 	}
+	nodeHostPath := os.Getenv("NODE_HOST_PATH")
+	if nodeHostPath == "" {
+		nodeHostPath = "/mnt/hostpath"
+	}
 	return &hostPathProvisioner{
-		pvDir:    "/mnt/hostpath",
+		pvDir:    nodeHostPath,
 		identity: nodeName,
 	}
 }


### PR DESCRIPTION
Hello!

I came across your helm chart for hostpath provisioner. It's great. But I have a need to custom set the actual path on the node. 

I modified the chart first, and then found it was acting weird(e.g., the chart was setting it correctly, and a directory for the pvc directory was showing up where it should, but nothing was being written to it. After some investigation, I found it was also still using /mnt/hostpath and creating a pvc directory there too! =) 

Once I dug into your code in this repo, I saw that it was hard coded here.

I am not sure you were looking to take outside changes, but I thought I would send you the PR in case you don't mind.

This change should not effect your current helm chart as it defaults to what was hard coded.

Also expect a PR for the chart after I send this. That on the other hand is dependent on this change to the code and an updated "latest" docker image.

Kindest Regards! 
