### PR TITLE
adds support for naming provisioner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 IMAGE?=quay.io/rimusz/hostpath-provisioner
 
-TAG_GIT=$(IMAGE):v0.2.2
+TAG_GIT=$(IMAGE):v0.2.3
 TAG_LATEST=$(IMAGE):latest
 
 PHONY: all

--- a/hostpath-provisioner.go
+++ b/hostpath-provisioner.go
@@ -33,9 +33,16 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const (
-	provisionerName = "hostpath"
-)
+// Fetch provisioner name from environment variable HOSTPATH_PROVISIONER_NAME
+// if not set uses default hostpath name
+func GetProvisionerName() string {
+	provisionerName := os.Getenv("HOSTPATH_PROVISIONER_NAME")
+	if provisionerName == "" {
+		provisionerName = "hostpath"
+	}
+	return provisionerName
+}
+
 
 type hostPathProvisioner struct {
 	// The directory to create PV-backing directories in
@@ -145,6 +152,6 @@ func main() {
 
 	// Start the provision controller which will dynamically provision hostPath
 	// PVs
-	pc := controller.NewProvisionController(clientset, provisionerName, hostPathProvisioner, serverVersion.GitVersion)
+	pc := controller.NewProvisionController(clientset, GetProvisionerName(), hostPathProvisioner, serverVersion.GitVersion)
 	pc.Run(wait.NeverStop)
 }


### PR DESCRIPTION
Adds support for setting a name for the provisioner. Adds step of checking for HOSTPATH_PROVISIONER_NAME environment variable, if set it uses that value for the provisioner name, otherwise it defaults to "hostpath"